### PR TITLE
Localjar + no shared staging

### DIFF
--- a/sbt
+++ b/sbt
@@ -441,7 +441,7 @@ readConfigFile() {
 # can supply args to this runner
 if [[ -r "$sbt_opts_file" ]]; then
   vlog "Using sbt options defined in file $sbt_opts_file"
-  while read opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
+  while read opt; do for an_opt in $opt; do extra_sbt_opts+=("$an_opt"); done ; done < <(readConfigFile "$sbt_opts_file")
 elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
   vlog "Using sbt options defined in variable \$SBT_OPTS"
   extra_sbt_opts=( $SBT_OPTS )


### PR DESCRIPTION
Use a project specific staging directory if -no-share.
If we don't have an explicit sbt_jar, but there's a sbt-launch.jar in the same directory as the script, use it (and don't create the $sbt_launch_dir.
